### PR TITLE
Add council budget and booking management

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,10 +1,78 @@
-from flask import Flask, jsonify
+from dataclasses import dataclass, field
+from datetime import datetime
+import uuid
+from flask import Flask, jsonify, request, abort
+
+
+@dataclass
+class Booking:
+    id: str
+    council_id: str
+    hotel: str
+    cost: float
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class Council:
+    id: str
+    name: str
+    budget_remaining: float
+    bookings: list = field(default_factory=list)
+
+
+COUNCILS = {}
+BOOKINGS = {}
 
 app = Flask(__name__)
 
 @app.route('/health')
 def health():
     return jsonify({'status': 'ok'})
+
+
+@app.post('/councils')
+def create_council():
+    data = request.get_json(force=True)
+    if not data or 'name' not in data or 'budget' not in data:
+        abort(400, 'name and budget required')
+    cid = str(uuid.uuid4())
+    council = Council(id=cid, name=data['name'], budget_remaining=float(data['budget']))
+    COUNCILS[cid] = council
+    return jsonify({'id': cid, 'name': council.name, 'budget_remaining': council.budget_remaining}), 201
+
+
+@app.get('/councils/<council_id>/budget')
+def council_budget(council_id):
+    council = COUNCILS.get(council_id)
+    if not council:
+        abort(404)
+    return jsonify({
+        'id': council.id,
+        'name': council.name,
+        'budget_remaining': council.budget_remaining,
+        'bookings': [b.__dict__ for b in council.bookings]
+    })
+
+
+@app.post('/bookings')
+def create_booking():
+    data = request.get_json(force=True)
+    required = {'council_id', 'hotel', 'cost'}
+    if not data or not required.issubset(data):
+        abort(400, 'council_id, hotel and cost required')
+    council = COUNCILS.get(data['council_id'])
+    if not council:
+        abort(404, 'council not found')
+    cost = float(data['cost'])
+    if council.budget_remaining < cost:
+        abort(400, 'insufficient funds')
+    council.budget_remaining -= cost
+    bid = str(uuid.uuid4())
+    booking = Booking(id=bid, council_id=council.id, hotel=data['hotel'], cost=cost)
+    BOOKINGS[bid] = booking
+    council.bookings.append(booking)
+    return jsonify({'id': bid, 'hotel': booking.hotel, 'cost': booking.cost}), 201
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,6 +11,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 @pytest.fixture
 def app():
     module = importlib.import_module('backend.app')
+    # Reload module to reset global state between tests
+    module = importlib.reload(module)
     module.app.config.update({'TESTING': True})
     return module.app
 
@@ -24,3 +26,33 @@ def test_health(client):
     response = client.get('/health')
     assert response.status_code == 200
     assert response.get_json() == {'status': 'ok'}
+
+
+def create_council(client, name, budget):
+    resp = client.post('/councils', json={'name': name, 'budget': budget})
+    assert resp.status_code == 201
+    return resp.get_json()['id']
+
+
+def create_booking(client, council_id, hotel, cost):
+    return client.post('/bookings', json={'council_id': council_id, 'hotel': hotel, 'cost': cost})
+
+
+def test_booking_reduces_budget(client):
+    cid = create_council(client, 'Test Council', 200)
+    resp = create_booking(client, cid, 'Hotel A', 50)
+    assert resp.status_code == 201
+    budget_resp = client.get(f'/councils/{cid}/budget')
+    data = budget_resp.get_json()
+    assert data['budget_remaining'] == 150
+    assert len(data['bookings']) == 1
+
+
+def test_booking_insufficient_funds(client):
+    cid = create_council(client, 'Low Budget', 50)
+    resp = create_booking(client, cid, 'Hotel A', 100)
+    assert resp.status_code == 400
+    budget_resp = client.get(f'/councils/{cid}/budget')
+    data = budget_resp.get_json()
+    assert data['budget_remaining'] == 50
+    assert data['bookings'] == []


### PR DESCRIPTION
## Summary
- create in-memory Council and Booking dataclasses
- implement endpoints to create councils, make bookings with budget checks, and view council budget
- test booking flow including insufficient funds

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845f9c3de64833386e26b423ab2dfad